### PR TITLE
Eta calibration

### DIFF
--- a/macros/SetPlotStyle.py
+++ b/macros/SetPlotStyle.py
@@ -1,0 +1,60 @@
+import ROOT as r
+
+def SetPlotStyle():
+  # from ATLAS plot style macro
+  # use plain black on white colors
+  r.gStyle.SetFrameBorderMode(0)
+  r.gStyle.SetFrameFillColor(0)
+  r.gStyle.SetCanvasBorderMode(0)
+  r.gStyle.SetCanvasColor(0)
+  r.gStyle.SetPadBorderMode(0)
+  r.gStyle.SetPadColor(0)
+  r.gStyle.SetStatColor(0)
+  r.gStyle.SetHistLineColor(1)
+  r.gStyle.SetPalette(1)
+
+  # set the paper & margin sizes
+  r.gStyle.SetPaperSize(20,26)
+  r.gStyle.SetPadTopMargin(0.05)
+  r.gStyle.SetPadRightMargin(0.05)
+  r.gStyle.SetPadBottomMargin(0.16)
+  r.gStyle.SetPadLeftMargin(0.16)
+
+  # set title offsets (for axis label)
+  r.gStyle.SetTitleXOffset(1.4)
+  r.gStyle.SetTitleYOffset(1.4)
+
+  # use large fonts
+  r.gStyle.SetTextFont(42)
+  r.gStyle.SetTextSize(0.05)
+  r.gStyle.SetLabelFont(42,"x")
+  r.gStyle.SetTitleFont(42,"x")
+  r.gStyle.SetLabelFont(42,"y")
+  r.gStyle.SetTitleFont(42,"y")
+  r.gStyle.SetLabelFont(42,"z")
+  r.gStyle.SetTitleFont(42,"z")
+  r.gStyle.SetLabelSize(0.05,"x")
+  r.gStyle.SetTitleSize(0.05,"x")
+  r.gStyle.SetLabelSize(0.05,"y")
+  r.gStyle.SetTitleSize(0.05,"y")
+  r.gStyle.SetLabelSize(0.05,"z")
+  r.gStyle.SetTitleSize(0.05,"z")
+
+  # use bold lines and markers
+  r.gStyle.SetMarkerStyle(20)
+  r.gStyle.SetMarkerSize(1.2)
+  r.gStyle.SetHistLineWidth(2)
+  r.gStyle.SetLineStyleString(2,"[12 12]")
+
+  # get rid of error bar caps
+  # r.gStyle.SetEndErrorSize(0.)
+
+  # do not display any of the standard histogram decorations
+  r.gStyle.SetOptTitle(0)
+  r.gStyle.SetOptStat(0)
+#  r.gStyle.SetOptStat(111111)
+  r.gStyle.SetOptFit(0)
+
+  # put tick marks on top and RHS of plots
+  r.gStyle.SetPadTickX(1)
+  r.gStyle.SetPadTickY(1)

--- a/macros/plot_calibParams.py
+++ b/macros/plot_calibParams.py
@@ -1,0 +1,150 @@
+import ROOT as r
+from array import array
+from math import log10, floor
+from SetPlotStyle import SetPlotStyle
+SetPlotStyle()
+r.gROOT.SetBatch()
+
+etaRegions = [
+    "1p7_1p9",
+    "1p9_2p0",
+    "2p0_2p1",
+    "2p1_2p2",
+    "2p2_2p3",
+    "2p3_2p4",
+    "2p4_2p5",
+    "2p5_2p6",
+    "2p6_2p8",
+]
+
+FEOptions = [
+	'Threshold',
+	'BestChoice',
+	'STC',
+	'Mixed'
+]
+
+inputFileFormat = 'plots/out_eta_cuts_{FEOption}_EtaParam_TEST/{FEOption}{etaRegion}_profile.root'
+
+niceColours = [ 632, 600, 417, 604 ]
+
+def parseMinMaxEta( etaRegion ) :
+	minEta = float( etaRegion.split('_')[0].replace('p','.') )
+	maxEta = float( etaRegion.split('_')[-1].replace('p','.') )
+	return minEta, maxEta
+
+def getMidEta(minEta, maxEta):
+	if minEta < maxEta :
+		return minEta + abs(maxEta - minEta) / 2
+	else:
+		return maxEta + abs(maxEta - minEta) / 2
+
+
+allGraphs = {}
+
+for index, FEOption in enumerate(FEOptions):
+	for i_fitParam in range(3):
+		canvas = r.TCanvas("can"+str(i_fitParam), "can"+str(i_fitParam), 800, 900)
+		graph = r.TGraphErrors(len(etaRegions) )
+
+		graph_up = r.TGraphErrors(len(etaRegions) )
+		graph_down = r.TGraphErrors(len(etaRegions) )
+
+		etas, fitParams = array( 'd' ), array( 'd' )
+
+		for i, etaRegion in enumerate(etaRegions):
+			# print inputFileFormat.format(etaRegion=etaRegion)
+			inputFile = r.TFile( inputFileFormat.format(FEOption=FEOption, etaRegion=etaRegion), 'READ' )
+			c1 = inputFile.Get('c1')
+			f = c1.GetPrimitive('f_mean')
+			f_up = c1.GetPrimitive('f_rmsup')
+			f_down = c1.GetPrimitive('f_rmsdown')
+
+
+
+			minEta, maxEta = parseMinMaxEta(etaRegion)
+			midEta = getMidEta(minEta, maxEta)
+			graph.SetPoint( i, midEta, f.GetParameter(i_fitParam))
+			graph.SetPointError( i, 0, f.GetParError(i_fitParam))
+
+			graph_up.SetPoint( i, midEta, f_up.GetParameter(i_fitParam))
+			graph_up.SetPointError( i, 0, f_up.GetParError(i_fitParam))
+
+			graph_down.SetPoint( i, midEta, f_down.GetParameter(i_fitParam))
+			graph_down.SetPointError( i, 0, f_down.GetParError(i_fitParam))
+
+
+		canvas.cd()
+		graph.SetLineColor( niceColours[index] )
+		graph.SetLineWidth( 2 )
+		graph.SetMarkerColor( niceColours[index] )
+		graph.SetMarkerStyle( 21 )
+
+		fitFunction = None
+		fitFunctionName = 'pol1'
+		if i_fitParam == 0:
+			fitFunctionName = 'pol2'
+		elif i_fitParam == 1:
+			fitFunctionName = 'pol2'
+
+		graph.Fit(fitFunctionName, '0', '', 1.7, 2.8)
+		fitFunction = graph.GetFunction(fitFunctionName)
+
+		print 'Fit probability :',fitFunction.GetProb()
+
+		graph_up.SetLineColor( 9 )
+		graph_up.SetLineWidth( 2 )
+		graph_up.SetMarkerColor( 9 )
+		graph_up.SetMarkerStyle( 22 )
+
+		graph_down.SetLineColor( 9 )
+		graph_down.SetLineWidth( 2 )
+		graph_down.SetMarkerColor( 9 )
+		graph_down.SetMarkerStyle( 23 )
+
+		mg = r.TMultiGraph();
+		mg.Add(graph)
+
+		mg.GetXaxis().SetTitle( '#eta' )
+		yAxisTitle = 'x^{2} coefficient'
+		if i_fitParam == 0:
+			yAxisTitle = 'Intercept'
+		elif i_fitParam == 1:
+			yAxisTitle = 'x coefficient'
+		mg.GetYaxis().SetTitle( yAxisTitle )
+
+
+		print allGraphs
+		if yAxisTitle not in allGraphs.keys():
+			allGraphs[yAxisTitle] = {}
+		allGraphs[yAxisTitle][FEOption] = graph.Clone()
+
+	# raw_input('...')
+
+r.gROOT.SetBatch(0)
+for coefficient in allGraphs.keys():
+	canvas = r.TCanvas("can_"+coefficient, "can_"+coefficient, 800, 900)
+	mg = r.TMultiGraph();
+	mg.GetXaxis().SetTitle( '|#eta|' )
+	mg.GetYaxis().SetTitle( coefficient )
+	legend = r.TLegend(0.2, 0.7, 0.5, 0.9)
+	legend.SetFillStyle(0);
+	legend.SetBorderSize(0);
+	legend.SetTextSize(0.04);
+	legend.SetTextFont(42);
+	for FEOption, graph in allGraphs[coefficient].iteritems():
+		mg.Add( graph )
+		legend.AddEntry( graph, FEOption, 'P')
+	mg.Draw('AP')
+
+	legend.Draw()
+	canvas.Update()
+	mg.SetMinimum( mg.GetYaxis().GetXmin() * 0.8 );
+	if coefficient is 'x^{2} coefficient':
+		print r.gPad.GetLeftMargin()
+		r.gPad.SetLeftMargin(0.2)
+		mg.GetYaxis().SetTitleOffset(1.9)
+	mg.SetMaximum( mg.GetYaxis().GetXmax() * 1.3 );
+	canvas.Update()
+	canvas.Print('calibParam_{coefficient}.pdf'.format(coefficient = coefficient))
+

--- a/macros/plot_resolutions.py
+++ b/macros/plot_resolutions.py
@@ -1,0 +1,66 @@
+import ROOT as r
+from array import array
+from math import log10, floor
+from SetPlotStyle import SetPlotStyle
+from collections import OrderedDict
+SetPlotStyle()
+
+
+
+methodsAndInputFiles = OrderedDict()
+# methodsAndInputFiles['Threshold'] = 'plots/out_eta_cuts_Threshold_EtaParam_TEST/Threshold1p7_2p8_profileresolution.root'
+# methodsAndInputFiles['Best Choice'] = 'plots/out_eta_cuts_BestChoice_EtaParam_TEST/BestChoice1p7_2p8_profileresolution.root'
+# methodsAndInputFiles['STC'] = 'plots/out_eta_cuts_STC_EtaParam_TEST/STC1p7_2p8_profileresolution.root'
+
+
+# methodsAndInputFiles['Inclusive'] = 'plots/out_eta_cuts_Threshold_EtaParam_TEST/Threshold1p7_2p8_profileresolution.root'
+# methodsAndInputFiles['1.7 < |#eta| < 1.9'] = 'plots/out_eta_cuts_Threshold_EtaParam_TEST/Threshold1p7_1p9_profileresolution.root'
+# methodsAndInputFiles['2.6 < |#eta| < 2.8'] = 'plots/out_eta_cuts_Threshold_EtaParam_TEST/Threshold2p6_2p8_profileresolution.root'
+# methodsAndInputFiles['Calibration in jet #eta bins'] = 'plots/out_eta_cuts_Threshold_EtaParam_TEST/EtaCalibrated/Thresholdprofileresolution.root'
+
+# Before Eta Calibration
+methodsAndInputFiles['Threshold'] = 'plots/out_eta_cuts_ThresholdNew_EtaParam_TEST/Threshold1p7_2p8_profileresolution.root'
+methodsAndInputFiles['Best Choice'] = 'plots/out_eta_cuts_BestChoice_EtaParam_TEST/BestChoice1p7_2p8_profileresolution.root'
+methodsAndInputFiles['STC'] = 'plots/out_eta_cuts_STC_EtaParam_TEST/STC1p7_2p8_profileresolution.root'
+methodsAndInputFiles['Mixed'] = 'plots/out_eta_cuts_Mixed_EtaParam_TEST/Mixed1p7_2p8_profileresolution.root'
+
+# After Eta Calibration
+# methodsAndInputFiles['Threshold'] = 'plots/out_eta_cuts_ThresholdNew_EtaParam_TEST/EtaCalibrated/Thresholdprofileresolution.root'
+# methodsAndInputFiles['Best Choice'] = 'plots/out_eta_cuts_BestChoice_EtaParam_TEST/EtaCalibrated/BestChoiceprofileresolution.root'
+# methodsAndInputFiles['STC'] = 'plots/out_eta_cuts_STC_EtaParam_TEST/EtaCalibrated/STCprofileresolution.root'
+# methodsAndInputFiles['Mixed'] = 'plots/out_eta_cuts_Mixed_EtaParam_TEST/EtaCalibrated/Mixedprofileresolution.root'
+
+niceColours = [ 632, 600, 417, 604 ]
+
+canvas = r.TCanvas("can", "can", 900, 900)
+legend = r.TLegend(0.3, 0.6, 0.8, 0.8)
+legend.SetFillStyle(0);
+legend.SetBorderSize(0);
+legend.SetTextSize(0.04);
+legend.SetTextFont(42);
+
+for i, (method, inputFileName) in enumerate( methodsAndInputFiles.iteritems() ):
+	inputFile = r.TFile( inputFileName, 'READ' )
+	c1 = inputFile.Get('c1')
+	g = c1.GetPrimitive('Graph')
+
+	g.GetXaxis().SetTitle('gen p_{T}')
+	g.GetYaxis().SetTitle('Resolution')
+	g.SetLineColor(niceColours[i])
+	g.SetMarkerColor(niceColours[i])
+	g.SetMarkerStyle(1)
+	g.SetMarkerSize(1)
+
+	legend.AddEntry( g, method, 'LP')
+
+	canvas.cd()
+	if i == 0:
+		g.Draw('AP')
+	else :
+		g.Draw('PSAME')
+legend.Draw()
+canvas.SetGridy()
+canvas.Update()
+# raw_input('...')
+
+canvas.Print('compareResolutions.pdf')

--- a/src/Plotter.cxx
+++ b/src/Plotter.cxx
@@ -5,6 +5,7 @@ Plotter::Plotter( CmdLine * cmd ){
 
   _outdir = cmd->string_val( "--outdir" );
   std::system( ("mkdir -p plots/" + _outdir )   .c_str() );
+  std::system( ("mkdir -p plots/" + _outdir + "/EtaCalibrated/" )   .c_str() );
 
   InitialiseLegend();
   InitialiseCanvas();
@@ -69,6 +70,7 @@ void Plotter::DrawGraphs(std::vector<TGraphErrors*>& graphs, std::vector<TString
   int i = 0;
     for (auto &graph: graphs ){    
       
+      graph->SetLineWidth(2.5);
       graph->SetLineColor(i+1);      
       if(i>3){
 	graph->SetLineColor(i+2);

--- a/src/plot_ClusterDistributions.cxx
+++ b/src/plot_ClusterDistributions.cxx
@@ -73,10 +73,35 @@ void HGC::plot_GenRecoET(){
   
   TString file = VBF_HGG_PU200_SuperTC_ScintillatorStudies_DR0p2;
 
-  // std::vector<TString> trees = { tree_stc_validation, tree_stc};
-  // std::vector<TString> description = { "STC4_CTC4", "STC4_16"};
-  // std::vector<TString> legend = { "STC4+CTC4", "STC4+16"};
-  // std::string algo = "Fp8BestchoiceDummyHistomaxNtup";
+  std::vector<TString> etaCuts = {
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<1.9",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.9 && abs(genjet_eta[VBF_parton_genjet])<2.1",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>2.1 && abs(genjet_eta[VBF_parton_genjet])<2.3",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>2.3 && abs(genjet_eta[VBF_parton_genjet])<2.5",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>2.5 && abs(genjet_eta[VBF_parton_genjet])<2.8",
+   };
+  std::vector<TString> etaCutDescriptions = { 
+    "1p7_2p8",
+    "1p7_1p9",
+    "1p9_2p1",
+    "2p1_2p3",
+    "2p3_2p5",
+    "2p5_2p8",
+   };
+  std::vector<TString> etaCutLegend = {
+    "Inclusive",
+    "1.7 < |#eta| < 1.9",
+    "1.9 < |#eta| < 2.1",
+    "2.1 < |#eta| < 2.3",
+    "2.3 < |#eta| < 2.5",
+    "2.5 < |#eta| < 2.8",
+   };
+
+  std::vector<TString> fullDescriptions;
+
+  //  double y[7]={0,10,20,40,60,80,100};
+  //  double y[11]={0,10,20,30,40,50,60,70,80,90,100};
   
 
   // std::vector<TString> trees = { tree_stc, tree_bc_c4, tree_thresh};
@@ -93,6 +118,15 @@ void HGC::plot_GenRecoET(){
   // std::vector<TString> trees = { tree_thresh, tree_stc, tree_bc, tree_mixed};
   // std::vector<TString> description = { "th","stc","bc","mixed"};
   // std::vector<TString> legend = { "Threshold","STC","Best Choice", "Mixed"};
+
+  std::vector<TString> trees = { tree_bc, tree_bc_c1, tree_bc_c2, tree_bc_c4, tree_bc_c8,tree_bc_c16,};
+  std::vector<TString> description = { "bc", "bc-1","bc-2","bc-4","bc-8","bc-16"};
+  std::vector<TString> legend = { "bc", "bc-1","bc-2","bc-4","bc-8","bc-16"};
+
+  std::vector<TString> allLegends = {};
+
+
+  //  std::vector<TString> legend = { "bc", "bc-1","bc-2","bc-4"};
 
   // std::vector<TString> trees = { tree_bc};
   //  std::vector<TString> description = { "bc"};
@@ -120,68 +154,129 @@ void HGC::plot_GenRecoET(){
 
   for(unsigned int i=0;i<trees.size();i++){
 
-    //    if (i==1) file = file_VBF_BCCoarseH;
-    //    if (i==2 ) file = file_VBF_MixedFE;
-    //5 eta bins
-
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]", cuteta51, true  ) );
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta52, true  ) );
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta53, true  ) );
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta54, true  ) );
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta55, true  ) );
-
-
-    //Pion
-    //    histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[Pion_jets]:genjet_pt[Pion_genjet]", cut_pion, true  ) );
-    //Not separated (default)
-    //                histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut, true  ) );
+    for (unsigned int i_etaCut =0; i_etaCut < etaCuts.size(); ++i_etaCut ) {
+       // if (i==1) file = file2_QG_Pos_140;
+       // if (i==2) file = file2_QG_Pos_0;
+      //5 eta bins
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]", cuteta51, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta52, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta53, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta54, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta55, true  ) );
 
 
-     histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
+      //Pion
+      //    histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[Pion_jets]:genjet_pt[Pion_genjet]", cut_pion, true  ) );
+      //Not separated (default)
+      //                histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + files.at(i) + "/jet_ntuples_merged/ntuple_jet_merged_"+stats+".root"), "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut, true  ) );
 
-    //3D attempt
-    //         histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
-     //histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
+       // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
+       histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,etaCuts[i_etaCut], true  ) );
+       fullDescriptions.emplace_back( description.at(i) + etaCutDescriptions.at(i_etaCut) );
+       allLegends.emplace_back( etaCutLegend.at(i_etaCut) );
+      //3D attempt
+      //         histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
+
+       //histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
 
 
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cuteta52, true  ) );
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cuteta53, true  ) );
-    // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cuteta54, true  ) );
-    //    histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta55, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cuteta52, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cuteta53, true  ) );
+      // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cuteta54, true  ) );
+      //    histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cuteta55, true  ) );
 
+    }
   }
 
 
   std::vector<TProfile*> profiles;
 
+  std::vector<TH2F*> histos_2D;
+
+  std::vector<TGraphErrors*> graphsForEtaCalibPlot;
+  std::vector<TString> allLegendsForEtaCalibPlot = {};
+  std::vector<TString> graphLegendsForEtaCalibPlot = {
+    "Inclusive",
+    "1.7 < |#eta| < 1.9",
+    "2.5 < |#eta| < 2.8",
+   };
+
   for(unsigned int i=0;i<histobjects.size();i++){
-    TH2F * hist = plotter->Draw2D(histobjects.at(i), 15, x, 4000,0,400  ,description.at(i) );//VBF
-    //    TH2F * hist = plotter.Draw2D(histobjects.at(i), 10, y, 4000,0,400  ,description.at(i) );//Pion
+      TH2F * hist = plotter->Draw2D(histobjects.at(i), 15, x, 4000,0,400  ,fullDescriptions.at(i) );//VBF
+      //    TH2F * hist = plotter.Draw2D(histobjects.at(i), 10, y, 4000,0,400  ,description.at(i) );//Pion
+      histos_2D.emplace_back( hist );
+      TGraphErrors * graph = plotter->DrawProfile(hist  ,(fullDescriptions.at(i)+"_profile"), "s" );
+      graphs.emplace_back( graph );
 
-    graphs.emplace_back( plotter->DrawProfile(hist  ,(description.at(i)+"_profile"), "s" ) );
-    profiles.push_back( hist->ProfileX( "profile_mean_eff") );
-
-    // hist = plotter.Draw2D(histobjects2.at(i), 15, x, 4000,0,400  ,description.at(i) + "_high_eta");
-    // graphs.emplace_back( plotter.DrawProfile(hist  ,(description.at(i)+"_profile_high_eta"), "s" ) );
- 
+      if ( std::find(graphLegendsForEtaCalibPlot.begin(), graphLegendsForEtaCalibPlot.end(), allLegends.at(i)) != graphLegendsForEtaCalibPlot.end() ) {
+        graphsForEtaCalibPlot.emplace_back( graph );
+        allLegendsForEtaCalibPlot.emplace_back( allLegends.at(i) );
+      }
+      profiles.push_back( hist->ProfileX( fullDescriptions.at(i)+"profile_mean_eff") );
  }
 
+  // Now rerun procedure for calibrated jets
+  // For inclusive case, it's a sanity check
+  // For bins in eta, can obtain resolution after taking into account variation of calibration vs eta
+  for(unsigned int i=0;i<trees.size();i++){
 
-  plotter->DrawGraphs(graphs, legend);
+    // Calibrate and accumulate 2D plots from different eta bins
+    std::vector<TH2F*> calibrated_histos_2D_etaBins;
+    for (unsigned int i_etaCut =0; i_etaCut < etaCuts.size(); ++i_etaCut ) {
+
+      // Get calibration
+      TF1 * pol_choice = new TF1 ( "pol", "[0] + [1]*x + [2]*x*x" , 20 , 350);
+      TProfile * profile = profiles.at(i+i_etaCut);
+      profile->Fit( pol_choice, "R","",20,300);
+      double c = profile->GetFunction("pol")->GetParameter( 0 ); 
+      double b = profile->GetFunction("pol")->GetParameter( 1 ) ;
+      double a = profile->GetFunction("pol")->GetParameter( 2 ) ;
+
+      // Get 2D histogram of calibrated reco jet pt vs gen jet pt
+      TString calibratedJetPt("");
+      calibratedJetPt.Form("( -1.0 * %f + sqrt( %f*%f - 4*%f*(%f-jets_pt[VBF_parton_jets]) ) ) / (2 * %f)", b, b, b, a, c, a);
+      HistObject calibratedHist( "CalibratedJets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", calibratedJetPt+":genjet_pt[VBF_parton_genjet]" ,etaCuts[i_etaCut], true  );
+      // Exclude histogram from inclusive selection (i.e. all eta)
+      // Better way to do this, rather than depending on a label?
+      if ( !etaCutLegend[i_etaCut].Contains("Inclusive") ) {
+        TH2F * hist = plotter->Draw2D(calibratedHist, 15, x, 4000,0,400  ,"EtaCalibrated/"+fullDescriptions.at(i+i_etaCut) );
+        calibrated_histos_2D_etaBins.emplace_back( hist );
+        plotter->DrawProfile(hist  ,"EtaCalibrated/"+(fullDescriptions.at(i+i_etaCut)+"_profile"), "s" );
+      }
+
+    }
+
+    // Add plots of calibrated reco jet pt vs gen jet pt from the different eta bins
+    TH2F* calibrated_histo_2D = (TH2F*) calibrated_histos_2D_etaBins[0]->Clone();
+    for ( unsigned int i=1;i<calibrated_histos_2D_etaBins.size();i++ ) {
+      calibrated_histo_2D->Add( calibrated_histos_2D_etaBins[i] );
+    }
+    TGraphErrors * graph = plotter->DrawProfile(calibrated_histo_2D  ,("EtaCalibrated/profile"), "s" );
+
+    graphs.emplace_back( graph );
+    allLegends.emplace_back("After calibration in #eta");
+
+    graphsForEtaCalibPlot.emplace_back( graph );
+    graphLegendsForEtaCalibPlot.emplace_back("After calibration in #eta");
+  }
+  
+  // plotter->DrawGraphs(graphs, allLegends);
+  // //  plotter.DrawEtaGraphs(graphs );
+  // plotter->SaveFile( graphs );
+
+  
+  plotter->DrawGraphs(graphsForEtaCalibPlot, graphLegendsForEtaCalibPlot);
   //  plotter.DrawEtaGraphs(graphs );
-  plotter->SaveFile( graphs );
+  plotter->SaveFile( graphsForEtaCalibPlot );
 
-
-  TF1 * pol_choice = new TF1 ( "pol", "[0] + [1]*x + [2]*x*x" , 20 , 350);
-  TProfile * profile = profiles.at(0);
-
-  profile->Fit( pol_choice, "R","",20,300);
+  // TF1 * pol_choice = new TF1 ( "pol", "[0] + [1]*x + [2]*x*x" , 20 , 350);
+  // TProfile * profile = profiles.at(0);
+  // profile->Fit( pol_choice, "R","",20,300);
   
-  profile->GetFunction("pol")->GetParameter( 0 ); 
-  profile->GetFunction("pol")->GetParameter( 1 ) ;
-  profile->GetFunction("pol")->GetParameter( 2 ) ;
+  // profile->GetFunction("pol")->GetParameter( 0 ); 
+  // profile->GetFunction("pol")->GetParameter( 1 ) ;
+  // profile->GetFunction("pol")->GetParameter( 2 ) ;
 
-  
   delete plotter;
 
 
@@ -231,7 +326,7 @@ void HGC::plot_nC3D(){
 
 void HGC::JetStudies(double par0, double par1, double par2, std::string algo){
 
-        std::string stats = "*";
+  std::string stats = "*";
   //      std::string stats = "1*";
 
 

--- a/src/plot_ClusterDistributions.cxx
+++ b/src/plot_ClusterDistributions.cxx
@@ -73,6 +73,27 @@ void HGC::plot_GenRecoET(){
   
   TString file = VBF_HGG_PU200_SuperTC_ScintillatorStudies_DR0p2;
 
+  // std::vector<TString> trees = { tree_stc_validation, tree_stc};
+  // std::vector<TString> description = { "STC4_CTC4", "STC4_16"};
+  // std::vector<TString> legend = { "STC4+CTC4", "STC4+16"};
+  // std::string algo = "Fp8BestchoiceDummyHistomaxNtup";
+
+
+  // std::vector<TString> trees = { tree_stc, tree_bc_c4, tree_thresh};
+  // std::vector<TString> description = { "STC4_16", "BC_4", "Thresh"};
+  // std::vector<TString> legend = { "STC4+16", "BC-4", "Threshold"};
+  // std::string algo = "Fp8BestchoiceDummyHistomaxNtup";
+
+
+  // std::vector<TString> trees = { tree_bc, tree_bc,tree_bc};
+  // std::vector<TString> description = { "200", "140", "0"};
+  // std::vector<TString> legend = { "PU 200", "PU 140", "PU 0"};
+  // std::string algo = "Fp8BestchoiceDummyHistomaxNtup";
+
+  // std::vector<TString> trees = { tree_thresh, tree_stc, tree_bc, tree_mixed};
+  // std::vector<TString> description = { "th","stc","bc","mixed"};
+  // std::vector<TString> legend = { "Threshold","STC","Best Choice", "Mixed"};
+
   std::vector<TString> etaCuts = {
     "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8",
     "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<1.9",
@@ -100,34 +121,6 @@ void HGC::plot_GenRecoET(){
 
   std::vector<TString> fullDescriptions;
 
-  //  double y[7]={0,10,20,40,60,80,100};
-  //  double y[11]={0,10,20,30,40,50,60,70,80,90,100};
-  
-
-  // std::vector<TString> trees = { tree_stc, tree_bc_c4, tree_thresh};
-  // std::vector<TString> description = { "STC4_16", "BC_4", "Thresh"};
-  // std::vector<TString> legend = { "STC4+16", "BC-4", "Threshold"};
-  // std::string algo = "Fp8BestchoiceDummyHistomaxNtup";
-
-
-  // std::vector<TString> trees = { tree_bc, tree_bc,tree_bc};
-  // std::vector<TString> description = { "200", "140", "0"};
-  // std::vector<TString> legend = { "PU 200", "PU 140", "PU 0"};
-  // std::string algo = "Fp8BestchoiceDummyHistomaxNtup";
-  
-  // std::vector<TString> trees = { tree_thresh, tree_stc, tree_bc, tree_mixed};
-  // std::vector<TString> description = { "th","stc","bc","mixed"};
-  // std::vector<TString> legend = { "Threshold","STC","Best Choice", "Mixed"};
-
-  std::vector<TString> trees = { tree_bc, tree_bc_c1, tree_bc_c2, tree_bc_c4, tree_bc_c8,tree_bc_c16,};
-  std::vector<TString> description = { "bc", "bc-1","bc-2","bc-4","bc-8","bc-16"};
-  std::vector<TString> legend = { "bc", "bc-1","bc-2","bc-4","bc-8","bc-16"};
-
-  std::vector<TString> allLegends = {};
-
-
-  //  std::vector<TString> legend = { "bc", "bc-1","bc-2","bc-4"};
-
   // std::vector<TString> trees = { tree_bc};
   //  std::vector<TString> description = { "bc"};
   //  std::vector<TString> legend = { "Best Choice"};
@@ -151,6 +144,8 @@ void HGC::plot_GenRecoET(){
   std::vector<TString> trees = { tree_thresh, tree_stc, tree_stcScin4, tree_stcScin4C};
   std::vector<TString> description = { "th","stc4161616","stc416164","stc416164Coarse"};
   std::vector<TString> legend = { "Threshold","STC 4,16,16,16","STC 4,16,16,4","STC 4,16,16,4(Coarse)"};
+
+  std::vector<TString> allLegends = {};
 
   for(unsigned int i=0;i<trees.size();i++){
 
@@ -191,23 +186,23 @@ void HGC::plot_GenRecoET(){
 
   std::vector<TProfile*> profiles;
 
-  std::vector<TH2F*> histos_2D;
-
+  // Choose just a few plots for final resolution plot
   std::vector<TGraphErrors*> graphsForEtaCalibPlot;
   std::vector<TString> allLegendsForEtaCalibPlot = {};
   std::vector<TString> graphLegendsForEtaCalibPlot = {
     "Inclusive",
     "1.7 < |#eta| < 1.9",
     "2.5 < |#eta| < 2.8",
+    // Additional plot for "inclusive after calibrating in eta" will be added later
    };
 
   for(unsigned int i=0;i<histobjects.size();i++){
       TH2F * hist = plotter->Draw2D(histobjects.at(i), 15, x, 4000,0,400  ,fullDescriptions.at(i) );//VBF
       //    TH2F * hist = plotter.Draw2D(histobjects.at(i), 10, y, 4000,0,400  ,description.at(i) );//Pion
-      histos_2D.emplace_back( hist );
       TGraphErrors * graph = plotter->DrawProfile(hist  ,(fullDescriptions.at(i)+"_profile"), "s" );
       graphs.emplace_back( graph );
 
+      // Pick out a few graphs for plotting later
       if ( std::find(graphLegendsForEtaCalibPlot.begin(), graphLegendsForEtaCalibPlot.end(), allLegends.at(i)) != graphLegendsForEtaCalibPlot.end() ) {
         graphsForEtaCalibPlot.emplace_back( graph );
         allLegendsForEtaCalibPlot.emplace_back( allLegends.at(i) );
@@ -260,22 +255,24 @@ void HGC::plot_GenRecoET(){
     graphLegendsForEtaCalibPlot.emplace_back("After calibration in #eta");
   }
   
+  // Plot all resolution plots (one for each bin in eta, so many)
   // plotter->DrawGraphs(graphs, allLegends);
   // //  plotter.DrawEtaGraphs(graphs );
   // plotter->SaveFile( graphs );
 
-  
+
+  // This will just plot a few of the resolution plots to avoid cluttering canvase  
   plotter->DrawGraphs(graphsForEtaCalibPlot, graphLegendsForEtaCalibPlot);
-  //  plotter.DrawEtaGraphs(graphs );
   plotter->SaveFile( graphsForEtaCalibPlot );
 
-  // TF1 * pol_choice = new TF1 ( "pol", "[0] + [1]*x + [2]*x*x" , 20 , 350);
-  // TProfile * profile = profiles.at(0);
-  // profile->Fit( pol_choice, "R","",20,300);
+  TF1 * pol_choice = new TF1 ( "pol", "[0] + [1]*x + [2]*x*x" , 20 , 350);
+  TProfile * profile = profiles.at(0);
+
+  profile->Fit( pol_choice, "R","",20,300);
   
-  // profile->GetFunction("pol")->GetParameter( 0 ); 
-  // profile->GetFunction("pol")->GetParameter( 1 ) ;
-  // profile->GetFunction("pol")->GetParameter( 2 ) ;
+  profile->GetFunction("pol")->GetParameter( 0 ); 
+  profile->GetFunction("pol")->GetParameter( 1 ) ;
+  profile->GetFunction("pol")->GetParameter( 2 ) ;
 
   delete plotter;
 
@@ -326,7 +323,7 @@ void HGC::plot_nC3D(){
 
 void HGC::JetStudies(double par0, double par1, double par2, std::string algo){
 
-  std::string stats = "*";
+      std::string stats = "*";
   //      std::string stats = "1*";
 
 

--- a/src/plot_ClusterDistributions.cxx
+++ b/src/plot_ClusterDistributions.cxx
@@ -96,27 +96,44 @@ void HGC::plot_GenRecoET(){
 
   std::vector<TString> etaCuts = {
     "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8",
-    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<1.9",
-    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.9 && abs(genjet_eta[VBF_parton_genjet])<2.1",
-    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>2.1 && abs(genjet_eta[VBF_parton_genjet])<2.3",
-    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>2.3 && abs(genjet_eta[VBF_parton_genjet])<2.5",
-    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>2.5 && abs(genjet_eta[VBF_parton_genjet])<2.8",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>1.7 && abs(jets_eta[VBF_parton_jets])<1.9",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>1.9 && abs(jets_eta[VBF_parton_jets])<2.0",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.0 && abs(jets_eta[VBF_parton_jets])<2.1",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.1 && abs(jets_eta[VBF_parton_jets])<2.2",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.2 && abs(jets_eta[VBF_parton_jets])<2.3",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.3 && abs(jets_eta[VBF_parton_jets])<2.4",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.4 && abs(jets_eta[VBF_parton_jets])<2.5",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.5 && abs(jets_eta[VBF_parton_jets])<2.6",
+    "VBF_parton_genjet>=0 && VBF_parton_jets>=0 && abs(genjet_eta[VBF_parton_genjet])>1.7 && abs(genjet_eta[VBF_parton_genjet])<2.8 && abs(jets_eta[VBF_parton_jets])>2.6 && abs(jets_eta[VBF_parton_jets])<2.8",
    };
   std::vector<TString> etaCutDescriptions = { 
     "1p7_2p8",
+
     "1p7_1p9",
-    "1p9_2p1",
-    "2p1_2p3",
-    "2p3_2p5",
-    "2p5_2p8",
+    "1p9_2p0",
+    "2p0_2p1",
+    "2p1_2p2",
+    "2p2_2p3",
+    "2p3_2p4",
+    "2p4_2p5",
+    "2p5_2p6",
+    "2p6_2p8",
+
+
    };
   std::vector<TString> etaCutLegend = {
     "Inclusive",
+
     "1.7 < |#eta| < 1.9",
-    "1.9 < |#eta| < 2.1",
-    "2.1 < |#eta| < 2.3",
-    "2.3 < |#eta| < 2.5",
-    "2.5 < |#eta| < 2.8",
+    "1.9 < |#eta| < 2.0",
+    "2.0 < |#eta| < 2.1",
+    "2.1 < |#eta| < 2.2",
+    "2.2 < |#eta| < 2.3",
+    "2.3 < |#eta| < 2.4",
+    "2.4 < |#eta| < 2.5",
+    "2.5 < |#eta| < 2.6",
+    "2.6 < |#eta| < 2.8",
+
    };
 
   std::vector<TString> fullDescriptions;
@@ -168,7 +185,8 @@ void HGC::plot_GenRecoET(){
        // histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
        histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]:genjet_pt[VBF_parton_genjet]" ,etaCuts[i_etaCut], true  ) );
        fullDescriptions.emplace_back( description.at(i) + etaCutDescriptions.at(i_etaCut) );
-       allLegends.emplace_back( etaCutLegend.at(i_etaCut) );
+       allLegends.emplace_back( legend.at(i) + " " + etaCutLegend.at(i_etaCut) );
+
       //3D attempt
       //         histobjects.emplace_back( HistObject( "Jets", (snwebb + "/" + file + "/jet_ntuples_merged/ntuple_jet_merged_"+ trees.at(i) +"_"+stats+".root"), trees.at(i)+"_Jet", "", "jets_pt[VBF_parton_jets]*2.3/abs(jets_eta[VBF_parton_jets]):genjet_pt[VBF_parton_genjet]" ,cut_v9, true  ) );
 
@@ -241,18 +259,21 @@ void HGC::plot_GenRecoET(){
 
     }
 
+    if ( calibrated_histos_2D_etaBins.size() == 0 ) continue;
+
     // Add plots of calibrated reco jet pt vs gen jet pt from the different eta bins
     TH2F* calibrated_histo_2D = (TH2F*) calibrated_histos_2D_etaBins[0]->Clone();
     for ( unsigned int i=1;i<calibrated_histos_2D_etaBins.size();i++ ) {
       calibrated_histo_2D->Add( calibrated_histos_2D_etaBins[i] );
     }
-    TGraphErrors * graph = plotter->DrawProfile(calibrated_histo_2D  ,("EtaCalibrated/profile"), "s" );
+    TGraphErrors * graph = plotter->DrawProfile(calibrated_histo_2D  ,("EtaCalibrated/"+description.at(i)+"profile"), "s" );
 
     graphs.emplace_back( graph );
     allLegends.emplace_back("After calibration in #eta");
 
     graphsForEtaCalibPlot.emplace_back( graph );
-    graphLegendsForEtaCalibPlot.emplace_back("After calibration in #eta");
+    allLegendsForEtaCalibPlot.emplace_back(legend.at(i) + " After calibration in #eta");
+
   }
   
   // Plot all resolution plots (one for each bin in eta, so many)
@@ -261,8 +282,8 @@ void HGC::plot_GenRecoET(){
   // plotter->SaveFile( graphs );
 
 
-  // This will just plot a few of the resolution plots to avoid cluttering canvase  
-  plotter->DrawGraphs(graphsForEtaCalibPlot, graphLegendsForEtaCalibPlot);
+  // This will just plot a few of the resolution plots to avoid cluttering the canvas
+  plotter->DrawGraphs(graphsForEtaCalibPlot, allLegendsForEtaCalibPlot);
   plotter->SaveFile( graphsForEtaCalibPlot );
 
   TF1 * pol_choice = new TF1 ( "pol", "[0] + [1]*x + [2]*x*x" , 20 , 350);


### PR DESCRIPTION
## Include eta-dependent jet calibration in src/plot_ClusterDistributions.cxx
 - After producing the usual jet calibration plots, the same procedure is performed in bins of eta.  I then remake the 2D reco vs gen jet pt plots applying the calibration (the 2D plots are now essentially diagonal) in each eta bin.  I add the plots from each eta bin together, and then calculate the resolution as before.
## Add some plotting scripts I found useful
  - One grabs the resolution plots from different files and plots them, so I don't have to rerun the .cxx macro just to remake a plot, as the eta calibration now means the code takes longer to run
 - Another plots the parameters of the calibration curves as a function of eta
 - I wrote these in python rather than C++